### PR TITLE
Update to VS 201{7,9} and VsVim 2.7.0.0

### DIFF
--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -1,10 +1,9 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 
 $packageArgs = @{
-  packageName   = 'vsvim' # arbitrary name for the package, used in messages
-  vsixUrl       = 'https://visualstudiogallery.msdn.microsoft.com/59ca71b3-a4a3-46ca-8fe1-0e90e3f79329/file/6390/57/VsVim.vsix'
-  checksum      = 'f41c4d97ce6e5fc61f0242fc172f88e9'
-  checksumType  = 'md5' #default is md5, can also be sha1
-  # vsVersion     = 14 # vs2015 - left out, by default will install to latest visual studio
+  PackageName   = $env:ChocolateyPackageName
+  VsixUrl       = 'https://jaredparmsft.gallerycdn.vsassets.io/extensions/jaredparmsft/vsvim/2.7.0.0/1559137072898/VsVim.vsix'
+  Checksum      = 'BE4A1D7EFD28C34B1BD6D8D7475C979A91DBB4077E30DED32EC5F53ACF0C1103'
+  ChecksumType  = 'sha256'
 }
 Install-ChocolateyVsixPackage @packageArgs

--- a/tools/chocolateyinstall.ps1
+++ b/tools/chocolateyinstall.ps1
@@ -6,4 +6,4 @@ $packageArgs = @{
   Checksum      = 'BE4A1D7EFD28C34B1BD6D8D7475C979A91DBB4077E30DED32EC5F53ACF0C1103'
   ChecksumType  = 'sha256'
 }
-Install-ChocolateyVsixPackage @packageArgs
+Install-VisualStudioVsixExtension @packageArgs

--- a/vsvim.nuspec
+++ b/vsvim.nuspec
@@ -36,10 +36,9 @@ Note: This extension is being released by Jared, not by Microsoft.
     <licenseUrl>https://visualstudiogallery.msdn.microsoft.com/site/59ca71b3-a4a3-46ca-8fe1-0e90e3f79329/eula?licenseType=None</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <iconUrl>https://visualstudiogallery.msdn.microsoft.com/59ca71b3-a4a3-46ca-8fe1-0e90e3f79329/showImage/6395</iconUrl>
-    <!--<dependencies>
-      <dependency id="" version="__VERSION__" />
-      <dependency id="" />
-    </dependencies>-->
+    <dependencies>
+      <dependency id="chocolatey-visualstudio.extension" />
+    </dependencies>
     <releaseNotes></releaseNotes>
     <!--<provides></provides>-->
   </metadata>

--- a/vsvim.nuspec
+++ b/vsvim.nuspec
@@ -5,7 +5,7 @@
     <!-- Read this before publishing packages to chocolatey.org: https://github.com/chocolatey/chocolatey/wiki/CreatePackages -->
     <id>vsvim</id>
     <title>VsVim</title>
-    <version>2.0.1.0</version>
+    <version>2.7.0.0</version>
     <authors>JaredPar MSFT (Jared Parsons)</authors>
     <owners>Tim Abell</owners>
     <summary>VIM emulation layer for Visual Studio</summary>


### PR DESCRIPTION
Thanks for packaging this! I noticed the version of VsVim on the Chocolatey registry was a bit out of date, and it wouldn't install with Visual Studio 2019 (and presumably also 2017). This PR fixes both of those. If you have any questions or suggestions I'm happy to help.

